### PR TITLE
AST implementation of @Tailrec

### DIFF
--- a/asttailrec.py
+++ b/asttailrec.py
@@ -1,55 +1,65 @@
 """
 Tail recursion should be as simple as a decorator
-A basic implementation here
+
+This uses the AST of python to do the rewriting to reduce to existing Tailrec implementation
 """
 import ast
 
-
 from inspect import getsource, isclass
 from textwrap import dedent
-from itertools import takewhile
 
 from tailrec import Tailrec, Tailcall
 
-__all__ = ["ASTTailRec"]
+__all__ = ["ASTTailrec"]
+
 
 class TailTransformer(ast.NodeTransformer):
     """
-    Replace all the return statements we see that are just function calls
-    to the same function
+    Replace all the return statements we see that are just recursive function calls
+    to the same name with `name.recur`
     """
+
     def __init__(self, name, *args, **kwargs):
         self.name = name
         super(TailTransformer).__init__(*args, **kwargs)
 
     def visit_Return(self, node):
-        print(ast.dump(node))
         if isinstance(node.value, ast.Call):
             if node.value.func.id == self.name:
-                ctx = node.value.func.ctx
-                # node.value.func.attr = "recur"
+                # Since the dot syntax means that this an attribute call and not a function call, 
+                # we have to create a new node.
                 node.value.func = ast.Attribute(value=node.value.func, attr="recur", ctx=ast.Load())
+        # creating a new node doesn't always play nice with compile,
+        # so fix missing locations automatically
         ast.fix_missing_locations(node)
-        print(ast.dump(node))
         return node
 
 
 def replace_decorator(func_tree):
     """
-    The ASTTailRec decorator wants to get rid of itself and replace
-    with Tailrec. 
+    The ASTTailrec decorator wants to get rid of itself and replace with Tailrec so we can
+    reduce this problem to already solved issue.
+
     """
     decorators = func_tree.body[0].decorator_list
     for dec in decorators:
-        if dec.id == 'ASTTailRec':
+        if dec.id == 'ASTTailrec':
             dec.id = 'Tailrec'
 
 
-def ASTTailRec(func):
+def ASTTailrec(func):
     """
-    This approach involves modifying the ast tree and is heavily inspired by 
-    Robin Hillard's pipeop library at https://github.com/robinhilliard/pipes
-    which was used as a reference when developing this decorator
+    This approach involves modifying the ast tree so we can just stick a decorator on such as
+
+    ```
+    @ASTTailrec
+    def fac(n, k=1):
+        if n == 1: return k
+        return fac(n-1, k*n)
+    ```
+
+    This function has been heavily inspired by  Robin Hillard's pipeop library at
+    https://github.com/robinhilliard/pipes. It was used as reference when developing this decorator
     """
     if isclass(func):
         raise TypeError("Cannot apply tail recursion to a class")
@@ -57,42 +67,36 @@ def ASTTailRec(func):
     in_context = func.__globals__
 
     new_context = {"Tailrec": Tailrec, "Tailcall": Tailcall}
-    # these need to be included in the imports else we're gonna have some trouble
-    # if they've already been imported, let that import hold precendece.
-    new_context.update(in_context)
 
+    # these need to be included in the imports else we're gonna have some trouble
+    # if they've already been imported, let that import hold precedence.
+    new_context.update(in_context)
 
     # now let's try and get the source
     source = getsource(func)
     # we get the tree
     tree = ast.parse(dedent(source))
-    # print(ast.dump(tree))
-
 
     # update for debugger
     first_line_number = func.__code__.co_firstlineno
     ast.increment_lineno(tree, first_line_number - 1)
-    source_indent = sum([1 for _ in takewhile(str.isspace, source)]) + 1
 
-    
-    # let's grab the name of the function here
+    # let's grab the name of the function here. func.__name__ is not reliable in case
+    # of other decorators and no use of `functools.wraps`
     func_name = tree.body[0].name
 
     # we want to replace with the standard tailrec decorator here
     replace_decorator(tree)
 
-    # now everytime we find the function, let's replace with func_name.recur
+    # now every time we find the function, let's replace with func_name.recur
     # as in the standard case
     tree = TailTransformer(func_name).visit(tree)
-    # print(ast.dump(tree))
 
     # now the tree has been modified satisfactorily, let's compile
     code = compile(tree, filename=new_context['__file__'], mode='exec')
 
-    # exec
+    # exec the code in the scope of the new_context
     exec(code, new_context)
 
     # and return the function
-    # print(ast.dump(tree))
     return new_context[func_name]
-

--- a/asttailrec.py
+++ b/asttailrec.py
@@ -1,0 +1,98 @@
+"""
+Tail recursion should be as simple as a decorator
+A basic implementation here
+"""
+import ast
+
+
+from inspect import getsource, isclass
+from textwrap import dedent
+from itertools import takewhile
+
+from tailrec import Tailrec, Tailcall
+
+__all__ = ["ASTTailRec"]
+
+class TailTransformer(ast.NodeTransformer):
+    """
+    Replace all the return statements we see that are just function calls
+    to the same function
+    """
+    def __init__(self, name, *args, **kwargs):
+        self.name = name
+        super(TailTransformer).__init__(*args, **kwargs)
+
+    def visit_Return(self, node):
+        print(ast.dump(node))
+        if isinstance(node.value, ast.Call):
+            if node.value.func.id == self.name:
+                ctx = node.value.func.ctx
+                # node.value.func.attr = "recur"
+                node.value.func = ast.Attribute(value=node.value.func, attr="recur", ctx=ast.Load())
+        ast.fix_missing_locations(node)
+        print(ast.dump(node))
+        return node
+
+
+def replace_decorator(func_tree):
+    """
+    The ASTTailRec decorator wants to get rid of itself and replace
+    with Tailrec. 
+    """
+    decorators = func_tree.body[0].decorator_list
+    for dec in decorators:
+        if dec.id == 'ASTTailRec':
+            dec.id = 'Tailrec'
+
+
+def ASTTailRec(func):
+    """
+    This approach involves modifying the ast tree and is heavily inspired by 
+    Robin Hillard's pipeop library at https://github.com/robinhilliard/pipes
+    which was used as a reference when developing this decorator
+    """
+    if isclass(func):
+        raise TypeError("Cannot apply tail recursion to a class")
+
+    in_context = func.__globals__
+
+    new_context = {"Tailrec": Tailrec, "Tailcall": Tailcall}
+    # these need to be included in the imports else we're gonna have some trouble
+    # if they've already been imported, let that import hold precendece.
+    new_context.update(in_context)
+
+
+    # now let's try and get the source
+    source = getsource(func)
+    # we get the tree
+    tree = ast.parse(dedent(source))
+    # print(ast.dump(tree))
+
+
+    # update for debugger
+    first_line_number = func.__code__.co_firstlineno
+    ast.increment_lineno(tree, first_line_number - 1)
+    source_indent = sum([1 for _ in takewhile(str.isspace, source)]) + 1
+
+    
+    # let's grab the name of the function here
+    func_name = tree.body[0].name
+
+    # we want to replace with the standard tailrec decorator here
+    replace_decorator(tree)
+
+    # now everytime we find the function, let's replace with func_name.recur
+    # as in the standard case
+    tree = TailTransformer(func_name).visit(tree)
+    # print(ast.dump(tree))
+
+    # now the tree has been modified satisfactorily, let's compile
+    code = compile(tree, filename=new_context['__file__'], mode='exec')
+
+    # exec
+    exec(code, new_context)
+
+    # and return the function
+    # print(ast.dump(tree))
+    return new_context[func_name]
+

--- a/tailrec.py
+++ b/tailrec.py
@@ -4,11 +4,13 @@ class Tailrec:
             self.func = oper.func
         else:
             self.func = oper
+
     def __call__(self, *args, **kwargs):
         tailpos = self.func(*args, **kwargs)
         while isinstance(tailpos, Tailcall):
             tailpos = tailpos.evaluate()
         return tailpos
+
     def recur(self, *args, **kwargs):
         return Tailcall(self.func, args, kwargs)
 
@@ -20,5 +22,8 @@ class Tailcall:
             self.func = oper
         self.args = args
         self.kwargs = kwargs
+
     def evaluate(self):
         return self.func(*self.args, **self.kwargs)
+
+

--- a/test_asttail.py
+++ b/test_asttail.py
@@ -1,21 +1,24 @@
 #!/usr/bin/py.test
 
-from asttailrec import ASTTailRec
+from asttailrec import ASTTailrec
 import pytest
 
-@ASTTailRec
+
+@ASTTailrec
 def add_recur(a, b):
     if a <= 0: return b
-    return add_recur(a-1, b+1)
+    return add_recur(a - 1, b + 1)
+
 
 def add(a, b):
     if a <= 0: return b
-    return add(a-1, b+1)
+    return add(a - 1, b + 1)
 
 
 def test_recurse_error():
     with pytest.raises(RecursionError):
         add(1e5, 0)
+
 
 def test_no_recurse_error():
     add_recur(1e5, 0)

--- a/test_asttail.py
+++ b/test_asttail.py
@@ -1,0 +1,25 @@
+#!/usr/bin/py.test
+
+from asttailrec import ASTTailRec
+import pytest
+
+@ASTTailRec
+def add_recur(a, b):
+    if a <= 0: return b
+    return add_recur(a-1, b+1)
+
+def add(a, b):
+    if a <= 0: return b
+    return add(a-1, b+1)
+
+
+def test_recurse_error():
+    with pytest.raises(RecursionError):
+        add(1e5, 0)
+
+def test_no_recurse_error():
+    add_recur(1e5, 0)
+
+
+if __name__ == '__main__':
+    add_recur(10, 0)

--- a/test_tail.py
+++ b/test_tail.py
@@ -32,3 +32,8 @@ def test_recurse_error():
 
 def test_no_recurse_error():
     add_tail(1e5, 0)
+
+def test_funny():
+    from inspect import getsource
+    print(fac.__name__)
+    getsource(fac)

--- a/test_tail.py
+++ b/test_tail.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env py.test
+
+import pytest
+from tailrec import Tailrec
+
+
+def add_recur(a, b):
+    if a == 0: return b
+    return add_recur(a-1, b+1)
+
+@Tailrec
+def add_tail(a, b):
+    if a == 0: return b
+    return add_tail.recur(a-1, b+1)
+
+
+@Tailrec
+def fac(n, k = 1):
+    if n == 0:
+        return k
+    else:
+        return fac.recur(n = n - 1, k = n * k)
+
+def test_example():
+    from operator import mul
+    from functools import reduce
+    assert fac(200) == reduce(mul, (range(1,201)))
+
+def test_recurse_error():
+    with pytest.raises(RecursionError):
+        add_recur(1e5, 0)
+
+def test_no_recurse_error():
+    add_tail(1e5, 0)

--- a/test_tail.py
+++ b/test_tail.py
@@ -6,32 +6,37 @@ from tailrec import Tailrec
 
 def add_recur(a, b):
     if a == 0: return b
-    return add_recur(a-1, b+1)
+    return add_recur(a - 1, b + 1)
+
 
 @Tailrec
 def add_tail(a, b):
     if a == 0: return b
-    return add_tail.recur(a-1, b+1)
+    return add_tail.recur(a - 1, b + 1)
 
 
 @Tailrec
-def fac(n, k = 1):
+def fac(n, k=1):
     if n == 0:
         return k
     else:
-        return fac.recur(n = n - 1, k = n * k)
+        return fac.recur(n=n - 1, k=n * k)
+
 
 def test_example():
     from operator import mul
     from functools import reduce
-    assert fac(200) == reduce(mul, (range(1,201)))
+    assert fac(200) == reduce(mul, (range(1, 201)))
+
 
 def test_recurse_error():
     with pytest.raises(RecursionError):
         add_recur(1e5, 0)
 
+
 def test_no_recurse_error():
     add_tail(1e5, 0)
+
 
 def test_funny():
     from inspect import getsource

--- a/test_tail.py
+++ b/test_tail.py
@@ -37,8 +37,3 @@ def test_recurse_error():
 def test_no_recurse_error():
     add_tail(1e5, 0)
 
-
-def test_funny():
-    from inspect import getsource
-    print(fac.__name__)
-    getsource(fac)


### PR DESCRIPTION
Hi, I saw this project show up on reddit recently and thought it would be interesting to implement an AST based version based on a talk on ast I had been to somewhat recently. I used that talk's AST project as a reference for this.

This was also partially based on the lack of syntactic sugar for tailrecursion in other languages and my annoyance with this fact.

As a result you can now do

```
@ASTTailrec
def fac(n, k=1):
    if n == 1:
        return k
    return fac(n-1, n*k)
```

and it will be AST manipulated into 
```
@Tailrec
def fac(n, k = 1):
    if n == 1:
        return k
    return fac.recur(n - 1, n * k)
```

As per your original example.

The implementation effectively looks for all return statements with a recursive call and does the AST replacement.

I added some tests as well for extra deets.

I'm not show how robust this is, for example I noticed `inspect.getsource` on any function decorated with `Tailrec` failed so there might be some bad interactions, but thought you might enjoy this PR
